### PR TITLE
Change to GitHub releases for downloads

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -22,20 +22,22 @@ It's fun. But probably you don't need all this information. So we've also create
 
 <br><br>
 <center>
-<a class="downloadButton" href="https://cutt.ly/precious-plastic-kit">DOWNLOAD-KIT V4 🤙</a><br>
-<span align="center" class="downloadCount loading">0</span>
+<a id="kit" class="downloadButton js-getLinkDetails" href="https://api.github.com/repos/ONEARMY/precious-plastic-kit/releases/latest">DOWNLOAD-KIT V4 🤙</a><br>
+<span align="center" id="kit-downloadCount" class="fileStats">0</span>
+<span align="center" id="kit-fileSize" class="fileStats">0</span>
+<span align="center" id="kit-version" class="fileStats">0</span>
 </center>
 <img src="assets/download/arrow.png"/>
 <br>
 ## Starterkits
 
-|  Space  | Name       | Filesize  ||
+|  Space  | Name       | Filesize  |Download|
 |---|----------------|--------|--------|
-| <img src="assets/universe/badge-workspace.png" width="30"/>| Shredder Workspace |  420 MB  | <a class="small downloadButton" href="https://cutt.ly/starterkit-shredder">DOWNLOAD</a> |
-| <img src="assets/universe/badge-workspace.png" width="30"/>| Injection Workspace  | 260 MB        | <a class="small downloadButton" href="https://cutt.ly/starterkit-injection">DOWNLOAD</a>   |
-| <img src="assets/universe/badge-workspace.png" width="30"/>| Extrusion Workspace  | 690 MB       | <a class="small downloadButton" href="https://cutt.ly/starterkit-extrusion">DOWNLOAD</a>   |
-| <img src="assets/universe/badge-workspace.png" width="30"/>| Sheetpress Workspace | 320 MB        | <a class="small downloadButton" href="https://cutt.ly/starterkit-sheetpress">DOWNLOAD</a>    |
-| <img src="assets/universe/badge-workspace.png" width="30"/>| Mix Workspace | 300 MB       | <a class="small downloadButton" href="https://cutt.ly/starterkit-mix">DOWNLOAD</a>    |
-| <img src="assets/universe/badge-community-point.png" width="30"/>| Community Point | 90 MB         | <a class="small downloadButton" href="https://cutt.ly/starterkit-community">DOWNLOAD</a>    |
-| <img src="assets/universe/badge-collection-point.png" width="30"/>| Collection Point | 320 MB       | <a class="small downloadButton" href="https://cutt.ly/starterkit-collection">DOWNLOAD</a>     |
-| <img src="assets/universe/badge-machine-shop.png" width="30"/>| Machine Shop | 320 MB           | <a class="small downloadButton" href="https://cutt.ly/starterkit-machine">DOWNLOAD</a>     |
+| <img src="assets/universe/badge-workspace.png" width="30"/>| Shredder Workspace |  <span id="shredder-fileSize"></span> – <span id="shredder-version"></span>  | <a id="shredder" class="small downloadButton js-getLinkDetails" href="https://api.github.com/repos/ONEARMY/precious-plastic-starterkit-shredder/releases/latest">DOWNLOAD</a><div id="shredder-downloadCount"></div> |
+| <img src="assets/universe/badge-workspace.png" width="30"/>| Injection Workspace  | <span id="injection-fileSize"></span> – <span id="injection-version"></span>       | <a id="injection" class="small downloadButton js-getLinkDetails" href="https://api.github.com/repos/ONEARMY/precious-plastic-starterkit-injection/releases/latest">DOWNLOAD</a><div id="injection-downloadCount"></div>   |
+| <img src="assets/universe/badge-workspace.png" width="30"/>| Extrusion Workspace  | <span id="extrusion-fileSize"></span> – <span id="extrusion-version"></span>      | <a id="extrusion" class="small downloadButton js-getLinkDetails" href="https://api.github.com/repos/ONEARMY/precious-plastic-starterkit-extrusion/releases/latest">DOWNLOAD</a><div id="extrusion-downloadCount"></div>  |
+| <img src="assets/universe/badge-workspace.png" width="30"/>| Sheetpress Workspace | <span id="sheetpress-fileSize"></span> – <span id="sheetpress-version"></span>        | <a id="sheetpress" class="small downloadButton js-getLinkDetails" href="https://api.github.com/repos/ONEARMY/precious-plastic-starterkit-sheetpress/releases/latest">DOWNLOAD</a><div id="sheetpress-downloadCount"></div>    |
+| <img src="assets/universe/badge-workspace.png" width="30"/>| Mix Workspace | <span id="mix-fileSize"></span> – <span id="mix-version"></span>      | <a id="mix" class="small downloadButton js-getLinkDetails" href="https://api.github.com/repos/ONEARMY/precious-plastic-starterkit-mix/releases/latest">DOWNLOAD</a><div id="mix-downloadCount"></div>    |
+| <img src="assets/universe/badge-community-point.png" width="30"/>| Community Point | <span id="community-fileSize"></span> – <span id="community-version"></span>         | <a id="community" class="small downloadButton js-getLinkDetails" href="https://api.github.com/repos/ONEARMY/precious-plastic-starterkit-community/releases/latest">DOWNLOAD</a><div id="community-downloadCount"></div>    |
+| <img src="assets/universe/badge-collection-point.png" width="30"/>| Collection Point | <span id="collection-fileSize"></span> – <span id="collection-version"></span>       | <a id="collection" class="small downloadButton js-getLinkDetails" href="https://api.github.com/repos/ONEARMY/precious-plastic-starterkit-collection/releases/latest">DOWNLOAD</a><div id="collection-downloadCount"></div>     |
+| <img src="assets/universe/badge-machine-shop.png" width="30"/>| Machine Shop | <span id="machine-fileSize"></span> – <span id="machine-version"></span>           | <a id="machine" class="small downloadButton js-getLinkDetails" href="https://api.github.com/repos/ONEARMY/precious-plastic-starterkit-machine/releases/latest">DOWNLOAD</a><div id="machine-downloadCount"></div>     |

--- a/docs/download.md
+++ b/docs/download.md
@@ -31,11 +31,11 @@ It's fun. But probably you don't need all this information. So we've also create
 
 |  Space  | Name       | Filesize  ||
 |---|----------------|--------|--------|
-| <img src="assets/universe/badge-workspace.png" width="30"/>| Shredder Workspace |  420 MB  | <a class="smalldownloadButton" href="https://cutt.ly/starterkit-shredder">DOWNLOAD</a> |
-| <img src="assets/universe/badge-workspace.png" width="30"/>| Injection Workspace  | 260 MB        | <a class="smalldownloadButton" href="https://cutt.ly/starterkit-injection">DOWNLOAD</a>   |
-| <img src="assets/universe/badge-workspace.png" width="30"/>| Extrusion Workspace  | 690 MB       | <a class="smalldownloadButton" href="https://cutt.ly/starterkit-extrusion">DOWNLOAD</a>   |
-| <img src="assets/universe/badge-workspace.png" width="30"/>| Sheetpress Workspace | 320 MB        | <a class="smalldownloadButton" href="https://cutt.ly/starterkit-sheetpress">DOWNLOAD</a>    |
-| <img src="assets/universe/badge-workspace.png" width="30"/>| Mix Workspace | 300 MB       | <a class="smalldownloadButton" href="https://cutt.ly/starterkit-mix">DOWNLOAD</a>    |
-| <img src="assets/universe/badge-community-point.png" width="30"/>| Community Point | 90 MB         | <a class="smalldownloadButton" href="https://cutt.ly/starterkit-community">DOWNLOAD</a>    |
-| <img src="assets/universe/badge-collection-point.png" width="30"/>| Collection Point | 320 MB       | <a class="smalldownloadButton" href="https://cutt.ly/starterkit-collection">DOWNLOAD</a>     |
-| <img src="assets/universe/badge-machine-shop.png" width="30"/>| Machine Shop | 320 MB           | <a class="smalldownloadButton" href="https://cutt.ly/starterkit-machine">DOWNLOAD</a>     |
+| <img src="assets/universe/badge-workspace.png" width="30"/>| Shredder Workspace |  420 MB  | <a class="small downloadButton" href="https://cutt.ly/starterkit-shredder">DOWNLOAD</a> |
+| <img src="assets/universe/badge-workspace.png" width="30"/>| Injection Workspace  | 260 MB        | <a class="small downloadButton" href="https://cutt.ly/starterkit-injection">DOWNLOAD</a>   |
+| <img src="assets/universe/badge-workspace.png" width="30"/>| Extrusion Workspace  | 690 MB       | <a class="small downloadButton" href="https://cutt.ly/starterkit-extrusion">DOWNLOAD</a>   |
+| <img src="assets/universe/badge-workspace.png" width="30"/>| Sheetpress Workspace | 320 MB        | <a class="small downloadButton" href="https://cutt.ly/starterkit-sheetpress">DOWNLOAD</a>    |
+| <img src="assets/universe/badge-workspace.png" width="30"/>| Mix Workspace | 300 MB       | <a class="small downloadButton" href="https://cutt.ly/starterkit-mix">DOWNLOAD</a>    |
+| <img src="assets/universe/badge-community-point.png" width="30"/>| Community Point | 90 MB         | <a class="small downloadButton" href="https://cutt.ly/starterkit-community">DOWNLOAD</a>    |
+| <img src="assets/universe/badge-collection-point.png" width="30"/>| Collection Point | 320 MB       | <a class="small downloadButton" href="https://cutt.ly/starterkit-collection">DOWNLOAD</a>     |
+| <img src="assets/universe/badge-machine-shop.png" width="30"/>| Machine Shop | 320 MB           | <a class="small downloadButton" href="https://cutt.ly/starterkit-machine">DOWNLOAD</a>     |

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -32,14 +32,8 @@ body {
   text-decoration: none;
 }
 
-.smalldownloadButton {
-  background-color: rgb(131, 206, 235);
+.downloadButton.small {
   padding: 5px 8px;
-  color: #fff;
-  border: 2px solid rgb(110, 173, 198);
-  border-radius: 4px;
-  display: inline-block;
-  text-decoration: none;
   font-size: 12px;
 }
 

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -601,21 +601,16 @@ hr {
   }
 }
 
-.loading.downloadCount {
-  opacity: 0;
+.loaded.fileStats {
+  opacity: 1;
 }
 
-.downloadCount {
+.fileStats {
   color: gray !important;
   display: inline-block;
   padding: 0 10px;
   font-size: 0.6em;
   text-align: center;
-  opacity: 1;
-  transition: opacity 00ms;
+  opacity: 0;
   text-transform: uppercase;
-}
-
-.downloadCount:after {
-  content: " downloads";
 }

--- a/website/static/js/custom.js
+++ b/website/static/js/custom.js
@@ -136,7 +136,7 @@ function humanFormatBytes(bytes, decimals) {
   if (bytes === 0) return "0 Bytes";
   var k = 1024;
   // default to 2 decimal points
-  var dm = (decimals < 0 ? 0 : decimals) || 2;
+  var dm = (decimals < 0 ? 0 : decimals) || 0;
   var sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
   var i = Math.floor(Math.log(bytes) / Math.log(k));
   return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i];

--- a/website/static/js/custom.js
+++ b/website/static/js/custom.js
@@ -77,43 +77,87 @@ window.addEventListener("DOMContentLoaded", function() {
     initiateSlideshows();
   }
 
-  (function getKitDownloadCount() {
-    var kitUrl =
-      "https://cors-anywhere.herokuapp.com/https://cutt.ly/api/api.php?key=19f84938273aa758d86cc1f73a0e5b236ca06&stats=precious-plastic-kit";
+  function getDownloadStats(url, linkId) {
+    var $link = document.getElementById(linkId);
+    var $fileSize = document.getElementById(linkId + "-fileSize");
+    var $downloadCount = document.getElementById(linkId + "-downloadCount");
+    var $versionTag = document.getElementById(linkId + "-version");
     var request = new XMLHttpRequest();
-    request.open("GET", kitUrl, true);
+    request.open("GET", url, true);
+    request.setRequestHeader("Accept", "application/vnd.github.v3+json");
 
     request.onload = function() {
       if (this.status >= 200 && this.status < 400) {
         try {
           var data = JSON.parse(this.response);
-          var downloadCount = ["stats", "clicks"].reduce(function(obj, path) {
+          var asset = ["assets", 0].reduce(function(obj, path) {
             return (obj || {})[path];
           }, data);
-          writeToDomNodes(".downloadCount", downloadCount);
-          removeLoadingClass(".downloadCount");
-        } catch (error) {}
+          var downloadCount = asset.download_count || 0;
+          var fileSize = humanFormatBytes(asset.size || 0);
+          var tag = data.tag_name || "";
+          writeToDomNodes($downloadCount, downloadCount + " downloads ");
+          writeToDomNodes($fileSize, fileSize);
+          writeToDomNodes($versionTag, tag);
+          addLoadedClass([$link, $fileSize, $downloadCount, $versionTag]);
+        } catch (error) {
+          removeDomNode(
+            [$link, $fileSize, $downloadCount, $versionTag].filter(Boolean)
+          );
+        }
+      } else {
+        removeDomNode(
+          [$link, $fileSize, $downloadCount, $versionTag].filter(Boolean)
+        );
       }
     };
-
     request.send();
+  }
+
+  (function getStatsForDownloadButtons() {
+    var links = document.querySelectorAll(".js-getLinkDetails");
+    Array.from(links).forEach(function(node) {
+      getDownloadStats(node.href, node.id);
+      node.addEventListener("click", function(e) {
+        e.preventDefault();
+        console.log(e.target.href, e.target.id);
+      });
+    });
   })();
 });
 
-function removeLoadingClass(selector) {
-  Array.from(document.querySelectorAll(selector + ".loading")).forEach(function(
-    domNode
-  ) {
-    domNode.classList.remove("loading");
+function addLoadedClass(elements) {
+  elements.forEach(function(domNode) {
+    domNode.classList.add("loaded");
   });
 }
-function writeToDomNodes(selector, value) {
-  var nodes = Array.from(document.querySelectorAll(selector));
-  if (nodes.length > 0) {
-    nodes.forEach(function(n) {
-      n.innerHTML = value;
-    });
+
+function humanFormatBytes(bytes, decimals) {
+  if (bytes === 0) return "0 Bytes";
+  var k = 1024;
+  // default to 2 decimal points
+  var dm = (decimals < 0 ? 0 : decimals) || 2;
+  var sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+  var i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i];
+}
+
+function writeToDomNodes(el, value) {
+  if (el) {
+    el.innerHTML = value;
   }
+}
+
+function removeDomNode(elements) {
+  elements
+    .filter(function(b) {
+      return !b;
+    })
+    .forEach(function(node) {
+      if (node.parentNode) {
+        node.parentNode.removeChild(node);
+      }
+    });
 }
 
 /********************************************************************


### PR DESCRIPTION
BIG CAVEAT: there is a limit on how many requests to the GITHUB api we can do without logging in 😭 
So we might need a server that can cache the requests and authenticate.
A big one! 💥 

You can add a github release and display the stats where you want. In order to be flexible I had to make it a little more elaborate to use  🐢 

1. Add a link to the github release via the api: `https://api.github.com/repos/ONEARMY/precious-plastic-kit/releases/latest` <--- gets the latest kit from the GitHub api.
2. `<a href="https://api.github.com/repos/ONEARMY/precious-plastic-kit/releases/latest">Download</a>`
3. Give it a class of "js-getLinkDetails" and id. The `id` is used to decide where to display the file size, version and download count.
4. Add `<{whatever_tag} id="{id_from_above}-fileSize"></{whatever_tag}>`
5. full example:

```
<a class="downloadButton js-getLinkDetails" id="kit" href="https://api.github.com/repos/ONEARMY/precious-plastic-kit/releases/latest">Download</a>
stuff here and there
<p>things and more</p>
Now I want to show the download stats for the button above ☝️Here:
version: <span id="kit-version"></span>
downloads: <span id="kit-downloadCount"></span> NOTE: downloadCount gets the text "downloads" appended as a suffix.
file size: <span id="kit-fileSize"></span> NOTE: file size is written with 2 decimals and converted to MB, GB or KB depending on size.
```

Which produces:

[DOWNLOAD] button
...
...
...
version: V4.0.0
downloads: 420 downloads
file size: 1.49 GB



