### PR TITLE
fix: Corrects dead links to carabiner 

### DIFF
--- a/docs/create.md
+++ b/docs/create.md
@@ -89,7 +89,7 @@ It's worth noting that there are many ways of exploring moulds and new methods, 
 
 - [Make a handplane - simple mould](https://community.preciousplastic.com/how-to/make-a-handplane-simple-mould)<br>
 - [Make a broom hanger](https://community.preciousplastic.com/how-to/make-a-broom-hanger)<br>
-- [Make a carabiner CNC vs laser cut](https://community.preciousplastic.com/how-to/make-a-carabiner-cnc-vs-laser-cut)<br>
+- [Make a carabiner CNC vs laser cut](https://community.preciousplastic.com/how-to/make-a-carabiner-cnc-vs-lasercut)<br>
 - [Make an interlocking brick](https://community.preciousplastic.com/how-to/make-an-interlocking-brick)
 
 # 💰 Make plastic valuable

--- a/docs/create/design.md
+++ b/docs/create/design.md
@@ -234,7 +234,7 @@ This machine will allow you to be versatile with your production because all you
 
 <b>Products:</b>
 
-- [Make a carabiner CNC vs laser cut](https://community.preciousplastic.com/how-to/make-a-carabiner-cnc-vs-laser-cut)
+- [Make a carabiner CNC vs laser cut](https://community.preciousplastic.com/how-to/make-a-carabiner-cnc-vs-lasercut)
 - [Make a lightswitch and socket](https://community.preciousplastic.com/how-to/make-a-lightswitch-and-socket)
 - [Make an interlocking brick](https://community.preciousplastic.com/how-to/make-an-interlocking-brick)
 - [Make a handplane - simple mould](https://community.preciousplastic.com/how-to/make-a-handplane-simple-mould)


### PR DESCRIPTION
There were two specific pages which had incorrect links which pointed to a "how to not found" page

Create page - https://community.preciousplastic.com/academy/create
Design page - https://onearmy.github.io/academy/create/design

Would resolve if merged #96 