### PR TITLE
fix light links

### DIFF
--- a/docs/create.md
+++ b/docs/create.md
@@ -11,7 +11,7 @@ sidebar_label: Intro
 <style>
 :root {
   --highlight: #ffe084;
-  --links: rgb(131, 206, 235);
+  --links: #29bbe3;
   --hover: rgb(131, 206, 235);
 }
 </style>

--- a/docs/download.md
+++ b/docs/download.md
@@ -8,8 +8,8 @@ sidebar_label: Download-Kit
 
 <style>
 :root {
-  --highlight: #e1e1e1;
-  --links: rgb(131, 206, 235);
+  --highlight: #ffe084;
+  --links: #29bbe3;
   --hover: rgb(131, 206, 235);
 }
 </style>

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -10,8 +10,9 @@ sidebar_label: Hello! 🤙
 
 <style>
 :root {
-  --highlight: #e1e1e1;
-  --hover: #e1e1e1;
+  --highlight: #ffe084;
+  --links: #29bbe3;
+  --hover: rgb(131, 206, 235);
 }
 </style>
 

--- a/docs/plastic/basics.md
+++ b/docs/plastic/basics.md
@@ -9,8 +9,9 @@ sidebar_label: The Basics of Plastic
 
 <style>
 :root {
-  --highlight: #84cfec;
-  --hover:#84cfec;
+  --highlight: #ffe084;
+  --links: #29bbe3;
+  --hover: rgb(131, 206, 235);
 }
 </style>
 

--- a/docs/plastic/geeky.md
+++ b/docs/plastic/geeky.md
@@ -10,8 +10,9 @@ sidebar_label: Nerdy on Plastic
 
 <style>
 :root {
-  --highlight: #84cfec;
-  --hover: #84cfec;
+  --highlight: #ffe084;
+  --links: #29bbe3;
+  --hover: rgb(131, 206, 235);
 }
 </style>
 

--- a/docs/plastic/safety.md
+++ b/docs/plastic/safety.md
@@ -10,8 +10,9 @@ sidebar_label: Safety and Fumes
 
 <style>
 :root {
-  --highlight: #84cfec;
-  --hover: #84cfec;
+  --highlight: #ffe084;
+  --links: #29bbe3;
+  --hover: rgb(131, 206, 235);
 }
 </style>
 

--- a/docs/universe/branding.md
+++ b/docs/universe/branding.md
@@ -6,7 +6,8 @@ sidebar_label: Style guides
 
 <style>
 :root {
-  --highlight: #f2a5c1;
+  --highlight: #f090b3;
+  --links: #f090b3;
   --hover: #f2a5c1;
 }
 </style>

--- a/docs/universe/make-your-logo.md
+++ b/docs/universe/make-your-logo.md
@@ -6,7 +6,8 @@ sidebar_label: Make your logo
 
 <style>
 :root {
-  --highlight: #f2a5c1;
+  --highlight: #f090b3;
+  --links: #f090b3;
   --hover: #f2a5c1;
 }
 </style>

--- a/docs/universe/share-back.md
+++ b/docs/universe/share-back.md
@@ -6,7 +6,8 @@ sidebar_label: Share back
 
 <style>
 :root {
-  --highlight: #f2a5c1;
+  --highlight: #f090b3;
+  --links: #f090b3;
   --hover: #f2a5c1;
 }
 </style>

--- a/docs/universe/universe.md
+++ b/docs/universe/universe.md
@@ -6,7 +6,8 @@ sidebar_label: Universe explained
 
 <style>
 :root {
-  --highlight: #f2a5c1;
+  --highlight: #f090b3;
+  --links: #f090b3;
   --hover: #f2a5c1;
 }
 </style>
@@ -37,6 +38,7 @@ Within the Universe we have different Spaces. Each Space plays a different role.
 # The amount of Spaces locally.
 
 It's hard to say how many recycling Spaces you need in your local region. It depends on the density, amount of people and the volume of plastic they use. But to give you an indication here you can see the ratio between workspaces. Most noticeable: There are a big amount of Collection Points needed to gather the plastic, specially in the beginning to educate the people. And only 1 Community Point. In this way there is one point where Spaces can come together and collaborate with eachother.
+
 <img src="../assets/universe/number-spaces.jpg"/>
 
 


### PR DESCRIPTION
This PR addresses #148 by preferring the darker tone of the various brand colors for links, improving readability, and fixes the intro links as well:

**Before**

![image](https://user-images.githubusercontent.com/158590/167209829-88ce2e56-6053-4613-9754-603e488ed19f.png)

**After**

![image](https://user-images.githubusercontent.com/158590/167209861-0e218ce4-0db5-4349-b51d-52674a335d89.png)

https://user-images.githubusercontent.com/158590/167210428-779218bd-85d9-4ea3-b4d8-6c46a43058b9.mp4